### PR TITLE
Add curation related generators

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@ Invenio-Curations
 
 Invenio module for generic and customizable curations.
 
+Requires InvenioRDM v12 or higher
+
 TODO: Please provide feature overview of module
 
 Further documentation is available on
@@ -49,6 +51,8 @@ Additionally, notification builders have to be configured so that notifications 
 
     from invenio_curations.notifications.builders import (
         CurationRequestAcceptNotificationBuilder,
+        CurationRequestCritiqueNotificationBuilder,
+        CurationRequestResubmitNotificationBuilder,
         CurationRequestSubmitNotificationBuilder,
     )
     from invenio_records_resources.references.entity_resolvers import ServiceResultResolver
@@ -59,6 +63,8 @@ Additionally, notification builders have to be configured so that notifications 
         **NOTIFICATIONS_BUILDERS,
         # Curation request
         CurationRequestAcceptNotificationBuilder.type: CurationRequestAcceptNotificationBuilder,
+        CurationRequestCritiqueNotificationBuilder.type: CurationRequestCritiqueNotificationBuilder,
+        CurationRequestResubmitNotificationBuilder.type: CurationRequestResubmitNotificationBuilder,
         CurationRequestSubmitNotificationBuilder.type: CurationRequestSubmitNotificationBuilder,
     }
 

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,7 @@ In order to prevent this, the request permissions can be adapted such that the b
 Since we only want to change the behaviour of these community submission requests, we first check the type and then check the associated record. If the record has been accepted, the general request permissions will be applied. Otherwise, no one can accept the community submission.
 
 .. code-block:: python
+
     from invenio_rdm_records.requests import CommunityInclusion, CommunitySubmission
     from invenio_rdm_records.services.permissions import RDMRequestsPermissionPolicy
     from invenio_curations.services.generators import (
@@ -120,8 +121,6 @@ Since we only want to change the behaviour of these community submission request
 
 
     REQUESTS_PERMISSION_POLICY = CurationRDMRequestsPermissionPolicy
-
-
 
 
 Overwrite deposit view template

--- a/invenio_curations/notifications/builders.py
+++ b/invenio_curations/notifications/builders.py
@@ -63,10 +63,28 @@ class CurationRequestSubmitNotificationBuilder(
     recipients = [GroupMembersRecipient("request.receiver")]
 
 
+class CurationRequestResubmitNotificationBuilder(
+    CurationRequestActionNotificationBuilder
+):
+    """Notification builder for resubmit action."""
+
+    type = f"{CurationRequestActionNotificationBuilder.type}.resubmit"
+    recipients = [GroupMembersRecipient("request.receiver")]
+
+
 class CurationRequestAcceptNotificationBuilder(
     CurationRequestActionNotificationBuilder
 ):
     """Notification builder for accept action."""
 
     type = f"{CurationRequestActionNotificationBuilder.type}.accept"
+    recipients = [UserRecipient("request.created_by")]
+
+
+class CurationRequestCritiqueNotificationBuilder(
+    CurationRequestActionNotificationBuilder
+):
+    """Notification builder for critique action."""
+
+    type = f"{CurationRequestActionNotificationBuilder.type}.critique"
     recipients = [UserRecipient("request.created_by")]

--- a/invenio_curations/requests/curation.py
+++ b/invenio_curations/requests/curation.py
@@ -15,6 +15,8 @@ from invenio_requests.customizations import RequestState, RequestType, actions
 
 from invenio_curations.notifications.builders import (
     CurationRequestAcceptNotificationBuilder,
+    CurationRequestCritiqueNotificationBuilder,
+    CurationRequestResubmitNotificationBuilder,
     CurationRequestSubmitNotificationBuilder,
 )
 
@@ -145,12 +147,35 @@ class CurationCritiqueAction(actions.RequestAction):
     status_from = ["review"]
     status_to = "critiqued"
 
+    def execute(self, identity, uow):
+        """Execute the accept action."""
+        uow.register(
+            NotificationOp(
+                CurationRequestCritiqueNotificationBuilder.build(
+                    identity=identity, request=self.request
+                )
+            )
+        )
+
+        super().execute(identity, uow)
+
 
 class CurationResubmitAction(actions.RequestAction):
     """Mark request as ready for review."""
 
     status_from = ["critiqued", "accepted", "cancelled", "declined"]
     status_to = "resubmitted"
+
+    def execute(self, identity, uow):
+        """Execute the submit action."""
+        uow.register(
+            NotificationOp(
+                CurationRequestResubmitNotificationBuilder.build(
+                    identity=identity, request=self.request
+                )
+            )
+        )
+        super().execute(identity, uow)
 
 
 #

--- a/invenio_curations/services/components.py
+++ b/invenio_curations/services/components.py
@@ -80,6 +80,9 @@ class CurationComponent(ServiceComponent, ABC):
             )
             return
 
+        # TODO: Should updates be disallowed if the record/request is currently being reviewed?
+        # It could be possible that the record gets updated while a curator performs a review. The curator would be looking at an outdated record and the review might not be correct.
+
         # If a request is open, it still has to be reviewed eventually.
         if request["is_open"]:
             return
@@ -113,4 +116,4 @@ class CurationComponent(ServiceComponent, ABC):
 
         # Request is closed but draft was updated with new data. Put back for review
         if diff_list:
-            current_requests_service.execute_action(identity, request["id"], "submit")
+            current_requests_service.execute_action(identity, request["id"], "resubmit")

--- a/invenio_curations/services/generators.py
+++ b/invenio_curations/services/generators.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 Graz University of Technology.
+#
+# Invenio-Curations is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Curations related generators."""
+
+from invenio_access.permissions import system_identity
+from invenio_records_permissions.generators import ConditionalGenerator
+
+from ..proxies import current_curations_service
+
+
+class IfRequestTypes(ConditionalGenerator):
+    """Conditional generator for requests of certain types."""
+
+    def __init__(self, request_types, then_, else_):
+        """Constructor."""
+        self.request_types = set(request_types)
+        super().__init__(then_, else_)
+
+    def _condition(self, request=None, **kwargs):
+        """Check if the request type matches a configured type."""
+        if request is not None:
+            for request_type in self.request_types:
+                if isinstance(request.type, request_type):
+                    return True
+
+        return False
+
+
+class IfCurationRequestAccepted(ConditionalGenerator):
+    """Conditional generator for requests."""
+
+    def __init__(
+        self,
+        record_access_func=lambda request: request.topic.resolve(),
+        then_=None,
+        else_=None,
+    ):
+        """Constructor."""
+        self.record_access_func = record_access_func
+        super().__init__(then_ or [], else_ or [])
+
+    def _condition(self, request=None, **kwargs):
+        """Check if the curation request for the record has been accepted."""
+        if request is not None:
+            record_to_curate = self.record_access_func(request)
+            return (
+                current_curations_service.accepted_record(
+                    system_identity, record_to_curate
+                )
+                is not None
+            )
+
+        return False

--- a/invenio_curations/services/permissions.py
+++ b/invenio_curations/services/permissions.py
@@ -19,11 +19,11 @@ class CurationPermissionPolicy(RequestPermissionPolicy):
 
     can_read = RequestPermissionPolicy.can_read + [
         Status(
-            ["in_review", "reviewed", "revised"],
+            ["review", "critiqued", "resubmitted"],
             [Creator(), Receiver()],
         ),
     ]
     can_create_comment = can_read
-    can_action_in_review = RequestPermissionPolicy.can_action_accept
-    can_action_reviewed = RequestPermissionPolicy.can_action_accept
-    can_action_revised = RequestPermissionPolicy.can_action_cancel
+    can_action_review = RequestPermissionPolicy.can_action_accept
+    can_action_critique = RequestPermissionPolicy.can_action_accept
+    can_action_resubmit = RequestPermissionPolicy.can_action_cancel

--- a/invenio_curations/templates/semantic-ui/invenio_curations/overview.html
+++ b/invenio_curations/templates/semantic-ui/invenio_curations/overview.html
@@ -1,8 +1,9 @@
 {#
 Copyright (C) 2020 CERN.
 Copyright (C) 2020 Northwestern University.
+Copyright (C) 2024 Graz University of Technology.
 
-Invenio App RDM is free software; you can redistribute it and/or modify it
+Invenio-Curations is free software; you can redistribute it and/or modify it
 under the terms of the MIT License; see LICENSE file for more details.
 #}
 {%- set title = _("Requests") %}
@@ -16,15 +17,9 @@ under the terms of the MIT License; see LICENSE file for more details.
 {%- endblock javascript %}
 
 {%- block user_dashboard_body %}
-{% if has_permission %}
 
 <div id="invenio-search-config"
   data-invenio-search-config='{{ search_app_curations_requests_config(app_id="InvenioAppRdm.DashboardRequests") | tojson }}'>
 </div>
-{% else %}
-<div>
-  403
-</div>
-{% endif %}
 
 {%- endblock user_dashboard_body %}

--- a/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.critique.jinja
+++ b/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.critique.jinja
@@ -1,0 +1,76 @@
+{% set curation_request = notification.context.request %}
+{% set group = curation_request.receiver %}
+{% set creator = curation_request.created_by %}
+{% set record = curation_request.topic %}
+{% set request_id = curation_request.id %}
+{% set executing_user = notification.context.executing_user %}
+{% set message = notification.context.message | safe if notification.context.message else '' %}
+{% set record_title = record.metadata.title %}
+{% set curator_name = executing_user.username or executing_user.profile.full_name %}
+
+{# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
+{% set request_link = "{ui}/me/requests/{id}".format(
+    ui=config.SITE_UI_URL, id=request_id
+    )
+%}
+{% set account_settings_link = "{ui}/account/settings/notifications".format(
+    ui=config.SITE_UI_URL
+    )
+%}
+
+{%- block subject -%}
+       {{ _("📝 Curation request critiqued for '{record_title}'").format(record_title=record_title) }}
+{%- endblock subject -%}
+
+{%- block html_body -%}
+    <table style="font-family:'Lato',Helvetica,Arial,sans-serif;border-spacing:15px">
+        <tr>
+            <td>{{ _("The metadata curator '@{curator_name}' critiqued the record '{record_title}'").format(curator_name=curator_name, record_title=record_title) }}
+            {% if message %} 
+            {{ _(" with the following message:")}}
+            {% endif %}
+            </td>
+        </tr>
+        <tr>
+            {% if message %} 
+            <td><em>{{message}}</em></td>
+            {% endif %}
+        </tr>
+        <tr>
+            <td><a href="{{ request_link }}" class="button">{{ _("Check out the curation request")}}</a></td>
+        </tr>
+        <tr>
+            <td><strong>_</strong></td>
+        </tr>
+        <tr>
+            <td style="font-size:smaller">{{ _("This is an auto-generated message. To manage notifications, visit your")}} <a href="{{account_settings_link}}">{{ _("account settings")}}</a>.</td>
+        </tr>
+    </table>
+{%- endblock html_body %}
+
+{%- block plain_body -%}
+{{ _("The metadata curator @{curator_name} critiqued the record '{record_title}'").format(curator_name=curator_name, record_title=record_title) }}
+
+{% if message %} 
+{{ _("with the following message:")}}
+{{message}}
+{% endif %}
+
+[{{ _("Check out the curation request") }}]({{ request_link }})
+
+{{ _("This is an auto-generated message. To manage notifications, visit your account settings")}}
+{%- endblock plain_body %}
+
+{# Markdown for Slack/Mattermost/chat #}
+{%- block md_body -%}
+{{ _("The metadata curator *@{curator_name}* critiqued the record *{record_title}*").format(curator_name=curator_name, record_title=record_title) }}
+
+{% if message %} 
+{{ _("with the following message:")}}
+{{message}}
+{% endif %}
+
+[{{ _("Check out the curation request") }}]({{ request_link }})
+
+{{ _("This is an auto-generated message. To manage notifications, visit your account settings")}}
+{%- endblock md_body %}

--- a/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.resubmit.jinja
+++ b/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.resubmit.jinja
@@ -1,0 +1,75 @@
+{% set curation_request = notification.context.request %}
+{% set group = curation_request.receiver %}
+{% set creator = curation_request.created_by %}
+{% set record = curation_request.topic %}
+{% set request_id = curation_request.id %}
+{% set creator_name = creator.username or creator.profile.full_name %}
+{% set record_title = record.metadata.title %}
+{% set message = notification.context.message | safe if notification.context.message else '' %}
+
+{# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
+{% set request_link = "{ui}/me/requests/{id}".format(
+    ui=config.SITE_UI_URL, id=request_id
+    )
+%}
+{% set account_settings_link = "{ui}/account/settings/notifications".format(
+    ui=config.SITE_UI_URL
+    )
+%}
+
+{%- block subject -%}
+       {{ _("📥 Curation request resubmitted") }}
+{%- endblock subject -%}
+
+{%- block html_body -%}
+    <table style="font-family:'Lato',Helvetica,Arial,sans-serif;border-spacing:15px">
+        <tr>
+            <td>{{ _("The record '{record_title}' was resubmitted for curation by '@{creator_name}'").format(record_title=record_title, creator_name=creator_name) }}
+            {% if message %} 
+            {{ _(" with the following message:")}}
+            {% endif %}
+            </td>
+        </tr>
+        <tr>
+            {% if message %} 
+            <td><em>{{message}}</em></td>
+            {% endif %}
+        </tr>
+        <tr>
+            <td><a href="{{request_link}}" class="button">{{ _("Review the curation request")}}</a></td>
+        </tr>
+        <tr>
+            <td><strong>_</strong></td>
+        </tr>
+        <tr>
+            <td style="font-size:smaller">{{ _("This is an auto-generated message. To manage notifications, visit your")}} <a href="{{account_settings_link}}">{{ _("account settings")}}</a>.</td>
+        </tr>
+    </table>
+{%- endblock html_body %}
+
+{%- block plain_body -%}
+    {{ _("The record '{record_title}' was resubmitted for curation by @'{creator_name}'.").format(record_title=record_title, creator_name=creator_name) }}
+
+{% if message %} 
+{{ _("with the following message:")}}
+{{message}}
+{% endif %}
+
+[{{ _("Review the curation request") }}]({{ request_link }})
+
+{{ _("This is an auto-generated message. To manage notifications, visit your account settings")}}
+{%- endblock plain_body %}
+
+{# Markdown for Slack/Mattermost/chat #}
+{%- block md_body -%}
+{{ _("The record *'{record_title}'* was resubmitted for curation by *@'{creator_name}'*.").format(record_title=record_title, creator_name=creator_name) }}
+
+{% if message %} 
+{{ _("with the following message:")}}
+{{message}}
+{% endif %}
+
+[{{ _("Review the curation request") }}]({{ request_link }})
+
+{{ _("This is an auto-generated message. To manage notifications, visit your account settings")}}
+{%- endblock md_body %}

--- a/invenio_curations/templates/semantic-ui/invenio_requests/rdm-curation/index.html
+++ b/invenio_curations/templates/semantic-ui/invenio_requests/rdm-curation/index.html
@@ -1,27 +1,28 @@
 {# -*- coding: utf-8 -*-
 
-  This file is part of Invenio.
   Copyright (C) 2016-2023 CERN.
+  Copyright (C) 2024 Graz University of Technology.
 
-  Invenio is free software; you can redistribute it and/or modify it
+  Invenio-Curations is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
 #}
 
 {#
-  Renders the request details page when publishing a draft and including it in a community.
+  Renders the rdm-curation request details page.
 #}
 
 {% extends "invenio_requests/details/index.html" %}
-
-{% set active_dashboard_menu_item = 'curation-overview' %}
+{% set is_curator = current_user.has_role(config["CURATIONS_MODERATION_ROLE"]) %}
+{% set active_dashboard_menu_item = "curation-overview" if is_curator else "requests" %}
 
 {%- block request_header %}
-  {% set back_button_url = url_for("invenio_curations.curation_requests_overview") %}
+
+  {% set back_button_url = url_for("invenio_curations.curation_requests_overview" if is_curator else "invenio_app_rdm_users.requests") %}
   {% from "invenio_requests/macros/request_header.html" import inclusion_request_header %}
   {{ inclusion_request_header(
       request=invenio_request,
       record=record,
-      accepted=request_is_accepted,
+      accepted=False, 
       back_button_url=back_button_url,
       back_button_text=_("Back to requests")
     ) }}

--- a/invenio_curations/views/ui.py
+++ b/invenio_curations/views/ui.py
@@ -7,7 +7,7 @@
 
 """Curations ui views module."""
 
-from flask import Blueprint, g, render_template
+from flask import Blueprint, abort, g, render_template
 from flask_login import current_user
 from invenio_users_resources.proxies import current_user_resources
 
@@ -26,6 +26,9 @@ def user_has_curations_management_role(identity):
 
 def curation_requests_overview():
     """Display user dashboard page."""
+    if not user_has_curations_management_role(g.identity):
+        abort(403)
+
     url = current_user_resources.users_service.links_item_tpl.expand(
         g.identity, current_user
     )["avatar"]
@@ -34,7 +37,6 @@ def curation_requests_overview():
         "invenio_curations/overview.html",
         searchbar_config=dict(searchUrl="/"),
         user_avatar=url,
-        has_permission=user_has_curations_management_role(g.identity),
     )
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ packages = find:
 python_requires = >=3.9
 zip_safe = False
 install_requires =
-    invenio-requests>=4.1.0,<5.0.0
     invenio-drafts-resources>=3.0.0,<4.0.0
+    invenio-requests>=4.1.0,<5.0.0
 [options.extras_require]
 tests =
     pytest-black-ng>=0.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,12 @@ platforms = any
 url = https://github.com/tu-graz-library/invenio-curations
 classifiers =
     Development Status :: 5 - Production/Stable
+    Programming Language :: Python :: 3.12
 
 [options]
 include_package_data = True
 packages = find:
-python_requires = >=3.9
+python_requires = >=3.12
 zip_safe = False
 install_requires =
     invenio-drafts-resources>=3.0.0,<4.0.0


### PR DESCRIPTION
`IfRequestTypes` checks if a request is of a certain type.
`IfCurationRequestAccepted` will check if a curation request has been accepted for the given requests record.

These two generators allow to update the requests permission policy, such that a curation request has to be accepted before a community submission request can be accepted. This way, users will not see the `Accept and Publish` button for the community submission request unless they should actually be able to click it.