### PR TITLE
config: Provide notification builders as single variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,23 +49,15 @@ Additionally, notification builders have to be configured so that notifications 
 
 .. code-block:: python
 
-    from invenio_curations.notifications.builders import (
-        CurationRequestAcceptNotificationBuilder,
-        CurationRequestCritiqueNotificationBuilder,
-        CurationRequestResubmitNotificationBuilder,
-        CurationRequestSubmitNotificationBuilder,
-    )
-    from invenio_records_resources.references.entity_resolvers import ServiceResultResolver
     from invenio_app_rdm.config import NOTIFICATIONS_BUILDERS, NOTIFICATIONS_ENTITY_RESOLVERS
+    from invenio_curations.config import CURATIONS_NOTIFICATIONS_BUILDERS
+    from invenio_records_resources.references.entity_resolvers import ServiceResultResolver
 
     # enable sending of notifications when something's happening in the review
     NOTIFICATIONS_BUILDERS = {
         **NOTIFICATIONS_BUILDERS,
         # Curation request
-        CurationRequestAcceptNotificationBuilder.type: CurationRequestAcceptNotificationBuilder,
-        CurationRequestCritiqueNotificationBuilder.type: CurationRequestCritiqueNotificationBuilder,
-        CurationRequestResubmitNotificationBuilder.type: CurationRequestResubmitNotificationBuilder,
-        CurationRequestSubmitNotificationBuilder.type: CurationRequestSubmitNotificationBuilder,
+        **CURATIONS_NOTIFICATIONS_BUILDERS
     }
 
     # enable requests to target groups of users (i.e. `roles`)

--- a/invenio_curations/config.py
+++ b/invenio_curations/config.py
@@ -7,6 +7,12 @@
 
 """Invenio module for curations."""
 
+from invenio_curations.notifications.builders import (
+    CurationRequestAcceptNotificationBuilder,
+    CurationRequestCritiqueNotificationBuilder,
+    CurationRequestResubmitNotificationBuilder,
+    CurationRequestSubmitNotificationBuilder,
+)
 from invenio_curations.services import facets
 
 CURATIONS_FACETS = {
@@ -37,3 +43,14 @@ CURATIONS_SEARCH_REQUESTS = {
     "sort": ["bestmatch", "newest", "oldest"],
 }
 """Curation requests search configuration (i.e list of curations requests)"""
+
+CURATIONS_NOTIFICATIONS_BUILDERS = {
+    builder.type: builder
+    for builder in [
+        CurationRequestAcceptNotificationBuilder,
+        CurationRequestCritiqueNotificationBuilder,
+        CurationRequestResubmitNotificationBuilder,
+        CurationRequestSubmitNotificationBuilder,
+    ]
+}
+"""Curation related notification builders as map for easy import."""


### PR DESCRIPTION
Provide notification builders as a single variable for easy import.
This allows to gather all the builders under a single variable within this package. In an `invenio.cfg` file, only this variable will have to be imported and added to the builders. This reduces maintenance work for the `invenio.cfg` file and makes sure, that all the notification builders of this package are used. 