### PR TITLE
permissions: Allow record reviewers to also read/update request

### DIFF
--- a/invenio_curations/services/config.py
+++ b/invenio_curations/services/config.py
@@ -15,7 +15,7 @@ from invenio_requests.services.requests.config import RequestSearchOptions
 
 from invenio_curations.services import facets
 
-from .permissions import CurationRDMRequestPermissionPolicy
+from .permissions import CurationRDMRequestsPermissionPolicy
 
 
 class CurationsSearchOptions(RequestSearchOptions):
@@ -43,7 +43,7 @@ class CurationsServiceConfig(RecordServiceConfig, ConfiguratorMixin):
 
     # common configuration
     permission_policy_cls = FromConfig(
-        "REQUESTS_PERMISSION_POLICY", default=CurationRDMRequestPermissionPolicy
+        "REQUESTS_PERMISSION_POLICY", default=CurationRDMRequestsPermissionPolicy
     )
     # TODO: update search options?
     search = CurationsSearchOptions

--- a/invenio_curations/services/service.py
+++ b/invenio_curations/services/service.py
@@ -8,6 +8,7 @@
 """Curation service."""
 
 from flask import current_app
+from invenio_access.permissions import system_identity
 from invenio_accounts.models import Role
 from invenio_accounts.proxies import current_datastore
 from invenio_i18n import gettext as _
@@ -127,7 +128,8 @@ class CurationRequestService:
             ),
         }
 
-        if self.get_review(identity, topic):
+        # using system identity to ensure a request is fetched, if it exists. Even if the user would not have access.
+        if self.get_review(system_identity, topic):
             raise OpenRecordCurationRequestAlreadyExists()
 
         if data:


### PR DESCRIPTION
closes #24 #25
possibly closes #15 (to be tested)

Update the request permission policy to allow users who `can_manage` a record to also view the associated curation request.

There is also some renaming in this PR, which adds some noise. Maybe easier to compare the README instead of `permissions.py`. ~Could be solved by merging #22 and rebasing~