### PR TITLE
deposit: Save draft before creating/resubmitting a curation request

### DIFF
--- a/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/DepositBox.js
+++ b/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/DepositBox.js
@@ -100,6 +100,24 @@ export class DepositBoxComponent extends React.Component {
     this.loading = false;
   };
 
+  handleSave = () => {
+    this.loading = true;
+    try {
+      // We assume there is exactly one button named `save` which is the save draft button.
+      // Another approach would be to get the redux context from the deposit form and perform the same actions the `SaveButton` performs.
+      // However, the context is not exported from invenio-rdm-records at the moment. This implementation can be adapted if this changes.
+
+      // see
+      //  - SaveButton action: https://github.com/inveniosoftware/invenio-rdm-records/blob/a4fbec8dbde537244a58d905495fb6919029abaa/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/SaveButton/SaveButton.js#L25-L33
+      //  - DepositFormSubmitContext: https://github.com/inveniosoftware/invenio-rdm-records/blob/a4fbec8dbde537244a58d905495fb6919029abaa/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFormSubmitContext.js
+      let saveButton = document.getElementsByName("save")[0];
+      saveButton.click();
+    } catch (error) {
+      console.error("Error when trying to save the draft", error);
+    }
+    this.loading = false;
+  };
+
   render() {
     const { latestRequest } = this.state;
     const { record, permissions, groupsEnabled } = this.props;
@@ -126,11 +144,13 @@ export class DepositBoxComponent extends React.Component {
                   request={latestRequest}
                   record={record}
                   loading={this.loading}
-                  handleCreateRequest={async () => {
+                  handleCreateRequest={async (event) => {
+                    await this.handleSave(event);
                     await this.fetchCurationRequest();
                     await this.createCurationRequest();
                   }}
-                  handleResubmitRequest={async () => {
+                  handleResubmitRequest={async (event) => {
+                    await this.handleSave(event);
                     await this.resubmitCurationRequest();
                   }}
                 />


### PR DESCRIPTION
closes #23

Using good ol' vanilla js, first the save draft button is obtained from the document. Then the `click` action is called on the html element. It is assumed that only one element with the name `save` is present and this element is the save button.

This also handles all the state changing of the button, ensuring correct rendering.

[Screencast from 2024-10-03 12:11:27.webm](https://github.com/user-attachments/assets/dbf8fe1e-3609-409f-8f9e-367074d11b4c)
