### PR TITLE
Update request title

### DIFF
--- a/invenio_curations/services/components.py
+++ b/invenio_curations/services/components.py
@@ -68,7 +68,7 @@ class CurationComponent(ServiceComponent, ABC):
         # Delete draft for a published record.
         # Since only one request per record should exist, it is not deleted. Instead, put it back to accepted.
         current_requests_service.execute_action(
-            system_identity, request["id"], "cancel"
+            system_identity, request["id"], "cancel", uow=self.uow
         )
 
     def _check_update_request(
@@ -161,4 +161,6 @@ class CurationComponent(ServiceComponent, ABC):
 
         # Request is closed but draft was updated with new data. Put back for review
         if diff_list:
-            current_requests_service.execute_action(identity, request["id"], "resubmit")
+            current_requests_service.execute_action(
+                identity, request["id"], "resubmit", uow=self.uow
+            )

--- a/invenio_curations/services/permissions.py
+++ b/invenio_curations/services/permissions.py
@@ -107,6 +107,7 @@ class CurationRDMRequestsPermissionPolicy(RDMRequestsPermissionPolicy):
                 Creator(),
                 Receiver(),
                 TopicPermission(permission_name="can_review"),
+                SystemProcess(),
             ],
             else_=RDMRequestsPermissionPolicy.can_read,
         )


### PR DESCRIPTION
Update the curation request title, whenever the title of the draft changes (closes #27)

When a draft is deleted, a curation review is fetched. Since we would completely serialize this review and generate links, we would also try to resolve the topic of the review - which is a draft. However, when deleting a draft, it will be set to deleted before running the components. This will lead to a `PIDDoesNotExistError` in the generator. Such an exception will now be caught and an empty set will be returned instead of trying to read the permissions of the entity.

Pass uow to service calls. For some reason, we could end up in a state where a request's status is "resubmitted" in the database while it is `accepted` in opensearch. This lead to the request being displayed correctly on the request detail page (request read from database) but incorrectly on the record deposit page (request read from opensearch). Since when running the component, it is also read from opensearch, this would lead to the issue of trying to execute the request `resubmit` action on draft changes, even though it was already in `resubmitted` state.