### PR TITLE
deposit form: use record.updated to determine necessity of re-fetch

### DIFF
--- a/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/DepositBox.js
+++ b/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/DepositBox.js
@@ -141,12 +141,7 @@ export class DepositBoxComponent extends React.Component {
   checkShouldFetchCurationRequest = async () => {
     // Fetch curation request instantly when record was updated from an external component
     const { lastFetchedAt } = this.state;
-    const { lastFormikUpdatedAt } = this.props;
-
-    // Checking lastFormikUpdatedAt as `record.updated` is not deserialized from the backend response.
-    // If the relevant PR is merged or this change is added somewhere else, lastFormikUpdatedAt can be removed completely.
-    // PR: https://github.com/inveniosoftware/invenio-rdm-records/pull/1838
-    if (lastFetchedAt < lastFormikUpdatedAt) {
+    if (lastFetchedAt < this.record.updated) {
       this.resetInterval();
       this.fetchCurationRequest();
     }


### PR DESCRIPTION
* the required [PR for this in Invenio-RDM-Records](https://github.com/inveniosoftware/invenio-rdm-records/pull/1838) has been merged a while ago
* previously, the latest formik update was used to determine the necessity of a re-fetch
* however, since file uploads update the upload form very quickly this could lead to "spamming" of fetch requests - even to a degree where users run into rate limiting issues

---
before (see the button on the right):

![upload](https://github.com/user-attachments/assets/71154360-35f0-4ba9-b293-7a2576340ffc)


---
after:

![upload](https://github.com/user-attachments/assets/c13fd63a-a3e0-4e5d-8802-087594cfc563)