### PR TITLE
fix-ui: Fix start publication button showing with warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -254,6 +254,75 @@ The ``DepositBox`` overrides the record's lifecycle management box on the deposi
 It takes care of rendering the "publish" button only when appropriate in the curation workflow.
 The other ``curationComponentOverrides`` provide better rendering for the new elements (e.g. event types) in the request page.
 
+Optional UI: Set Curation request custom field
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Because there could be a need to inform the user about the curation workflow, a custom field at the end can be added just to show
+a specific message. In order to set this up, a basic invenio custom field in your instance could be configured.
+
+Create a new javascript file at assets/templates/custom_fields/RdmCuration.js
+
+.. code-block:: javascript
+
+    import React from 'react';
+    import { i18next } from "@translations/invenio_app_rdm/i18next";
+
+    const RdmCuration = () => {
+      return (
+        <div className='ui visible warning message'>
+          <h4> 
+          {i18next.t(
+            "Please create a curation request after saving the \
+            draft by clicking on Start Publication Process")}
+          </h4>
+        </div>
+      );
+    };
+
+    export default RdmCuration;
+
+
+Then add this block to the invenio.cfg to link the component to the actual custom-field.
+
+.. code-block:: python
+
+    from invenio_records_resources.services.custom_fields import BaseListCF
+    from marshmallow_utils.fields import SanitizedUnicode
+
+    class RdmCurationCF(BaseListCF):
+        """Experiments with title and program."""
+    
+        def __init__(self, name, **kwargs):
+            """Constructor."""
+            super().__init__(
+              name,
+              **kwargs
+            )
+    
+        @property
+        def mapping(self):
+            """Return the mapping."""
+            return {"type": "text"}
+
+    RDM_CUSTOM_FIELDS = [
+        RdmCurationCF(
+            name="rdm-curation",
+            field_cls=SanitizedUnicode
+        ),
+    ]
+
+    RDM_CUSTOM_FIELDS_UI = [
+        {
+            "section": _("Curation request"),
+            "fields": [
+                dict(
+                    field="rdm-curation",
+                    ui_widget="RdmCuration",
+                ),
+            ],
+            "hide_from_landing_page": True
+        }
+    ]
+
 
 Create curator role
 ~~~~~~~~~~~~~~~~~~~

--- a/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/DepositBox.js
+++ b/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/DepositBox.js
@@ -149,12 +149,32 @@ export class DepositBoxComponent extends React.Component {
     }
   };
 
+  setGreenLightForCurationRequest = () => {
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
+    let greenLightComponent = document.getElementsByClassName("positive visible top")
+    return greenLightComponent != null && greenLightComponent.length > 0
+=======
+=======
+    // TODO: For now this workaround assumes the deposit-form has a feedback banner triggered
+    // to show by the save button.
+    // Possible solutions to avoid this naive approach would be to explore how make use of
+    // invenio-checks (https://github.com/inveniosoftware/invenio-checks) in this module.
+>>>>>>> Stashed changes
+    let positiveFeedback = document.getElementById("positive-feedback-div") != null;
+    let infoFeedback = document.getElementById("info-feedback-div") != null;
+    
+    return positiveFeedback || infoFeedback;
+>>>>>>> Stashed changes
+  };
+
   render() {
     const { latestRequest } = this.state;
     const { record, permissions, groupsEnabled } = this.props;
 
     this.checkShouldFetchCurationRequest();
-
+    record.savedSuccessfully = this.setGreenLightForCurationRequest();
+    
     return (
       <Card className="access-right">
         <Form.Field required>

--- a/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/DepositBox.js
+++ b/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/DepositBox.js
@@ -150,22 +150,14 @@ export class DepositBoxComponent extends React.Component {
   };
 
   setGreenLightForCurationRequest = () => {
-<<<<<<< Updated upstream
-<<<<<<< Updated upstream
-    let greenLightComponent = document.getElementsByClassName("positive visible top")
-    return greenLightComponent != null && greenLightComponent.length > 0
-=======
-=======
     // TODO: For now this workaround assumes the deposit-form has a feedback banner triggered
     // to show by the save button.
     // Possible solutions to avoid this naive approach would be to explore how make use of
     // invenio-checks (https://github.com/inveniosoftware/invenio-checks) in this module.
->>>>>>> Stashed changes
     let positiveFeedback = document.getElementById("positive-feedback-div") != null;
     let infoFeedback = document.getElementById("info-feedback-div") != null;
     
     return positiveFeedback || infoFeedback;
->>>>>>> Stashed changes
   };
 
   render() {

--- a/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/RequestOrPublishButton.js
+++ b/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/RequestOrPublishButton.js
@@ -15,7 +15,7 @@ import { i18next } from "@translations/invenio_curations/i18next";
 export const RequestOrPublishButton = (props) => {
   const { request, record, handleCreateRequest, handleResubmitRequest, loading } =
     props;
-  const recordIdAvailable = record?.id != null;
+  const recordCurateable = record?.id != null && record?.savedSuccessfully;
   let elem = null;
 
   if (request) {
@@ -32,7 +32,7 @@ export const RequestOrPublishButton = (props) => {
             primary
             size="medium"
             type="button"
-            disabled={!recordIdAvailable}
+            disabled={!recordCurateable}
             positive
             icon
             labelPosition="left"
@@ -66,9 +66,9 @@ export const RequestOrPublishButton = (props) => {
   } else {
     elem = (
       <Popup
-        disabled={recordIdAvailable}
+        disabled={recordCurateable}
         content={i18next.t(
-          "Before creating a curation request, the draft has to be saved."
+          "Before creating a curation request, the draft has to be saved without any errors."
         )}
         position="top center"
         trigger={
@@ -79,7 +79,7 @@ export const RequestOrPublishButton = (props) => {
               primary
               size="medium"
               type="button"
-              disabled={!recordIdAvailable}
+              disabled={!recordCurateable}
               positive
               icon
               labelPosition="left"

--- a/invenio_curations/services/components.py
+++ b/invenio_curations/services/components.py
@@ -99,18 +99,7 @@ class CurationComponent(ServiceComponent, ABC):
             expand=True,
         )
 
-        # Inform user to create a curation request
         if not request:
-            errors.append(
-                {
-                    "field": "custom_fields.rdm-curation",
-                    "messages": [
-                        _(
-                            "Missing curation request. Please create a curation request, if the record is ready to be published."
-                        )
-                    ],
-                }
-            )
             return
 
         current_draft = self.service.draft_cls.pid.resolve(


### PR DESCRIPTION
- Start publication button is now enabled only when the record is saved successfully
- Replace warning top message with an optional custom field
- Updated README

Optional custom field:
![image](https://github.com/user-attachments/assets/bdaca9c4-12a3-48a3-8190-ad4b79227f94)
