### PR TITLE
templates: replace username with full name and email

### DIFF
--- a/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.accept.jinja
+++ b/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.accept.jinja
@@ -6,7 +6,7 @@
 {% set executing_user = notification.context.executing_user %}
 {% set message = notification.context.message | safe if notification.context.message else '' %}
 {% set record_title = record.metadata.title %}
-{% set curator_name = executing_user.username or executing_user.profile.full_name %}
+{% set curator_name = executing_user.profile.full_name + " <" + executing_user.email + ">" %}
 
 {# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
 {% set request_link = "{ui}/me/requests/{id}".format(

--- a/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.critique.jinja
+++ b/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.critique.jinja
@@ -6,7 +6,7 @@
 {% set executing_user = notification.context.executing_user %}
 {% set message = notification.context.message | safe if notification.context.message else '' %}
 {% set record_title = record.metadata.title %}
-{% set curator_name = executing_user.username or executing_user.profile.full_name %}
+{% set curator_name = executing_user.profile.full_name + " <" + executing_user.email + ">" %}
 
 {# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
 {% set request_link = "{ui}/me/requests/{id}".format(

--- a/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.resubmit.jinja
+++ b/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.resubmit.jinja
@@ -3,7 +3,7 @@
 {% set creator = curation_request.created_by %}
 {% set record = curation_request.topic %}
 {% set request_id = curation_request.id %}
-{% set creator_name = creator.username or creator.profile.full_name %}
+{% set creator_name = creator.profile.full_name + " <" + creator.email + ">" %}
 {% set record_title = record.metadata.title %}
 {% set message = notification.context.message | safe if notification.context.message else '' %}
 

--- a/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.review.jinja
+++ b/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.review.jinja
@@ -6,7 +6,7 @@
 {% set executing_user = notification.context.executing_user %}
 {% set message = notification.context.message | safe if notification.context.message else '' %}
 {% set record_title = record.metadata.title %}
-{% set curator_name = executing_user.username or executing_user.profile.full_name %}
+{% set curator_name = executing_user.profile.full_name + " <" + executing_user.email + ">" %}
 
 {# TODO: use request.links.self_html when issue issue is resolved: https://github.com/inveniosoftware/invenio-rdm-records/issues/1327 #}
 {% set request_link = "{ui}/me/requests/{id}".format(

--- a/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.submit.jinja
+++ b/invenio_curations/templates/semantic-ui/invenio_notifications/curation-request.submit.jinja
@@ -3,7 +3,7 @@
 {% set creator = curation_request.created_by %}
 {% set record = curation_request.topic %}
 {% set request_id = curation_request.id %}
-{% set creator_name = creator.username or creator.profile.full_name %}
+{% set creator_name = creator.profile.full_name + " <" + creator.email + ">" %}
 {% set record_title = record.metadata.title %}
 {% set message = notification.context.message | safe if notification.context.message else '' %}
 


### PR DESCRIPTION
- as per data stewards request, replaced usernames in jinja templates with full names followed by user email