### PR TITLE
fix(utils): handle the case that no user can be resolved by ID

### DIFF
--- a/invenio_curations/services/utils.py
+++ b/invenio_curations/services/utils.py
@@ -33,4 +33,4 @@ def is_identity_privileged(privileged_roles: list[str], identity: Identity) -> b
     """Check if given identity is privileged in curation context."""
     user = db.session.get(User, identity.id)
 
-    return any(role in privileged_roles for role in user.roles)
+    return any(role in privileged_roles for role in user.roles) if user else False


### PR DESCRIPTION
Recently we've hit the following error:
```
Time:               2025-12-31 21:24:18,457
Level:              ERROR
Location:           /var/instance/.venv/lib/python3.14/site-packages/flask/app.py:875
Function:           log_exception
Request URL:        https://test.researchdata.tuwien.ac.at/api/curations/publishing-data
User ID:            Anonymous
Error:              AttributeError


Message:

Exception on /curations/publishing-data [GET]
Traceback (most recent call last):
  File "/var/instance/.venv/lib/python3.14/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/var/instance/.venv/lib/python3.14/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/var/instance/.venv/lib/python3.14/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/instance/.venv/lib/python3.14/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_resources/resources.py", line 65, in view
    return view_meth()
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_resources/content_negotiation.py", line 116, in inner_content_negotiation
    return f(*args, **kwargs)
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_resources/parsers/decorators.py", line 51, in inner
    return f(self, *args, **kwargs)
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_resources/parsers/decorators.py", line 90, in inner
    return f(self, *args, **kwargs)
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_resources/responses.py", line 39, in inner
    res = f(*args, **kwargs)
  File "/var/instance/.venv/lib/python3.14/site-packages/invenio_curations/resources/resource.py", line 112, in get_publishing_data
    return self.service.get_publishing_data(g.identity), 200
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/var/instance/.venv/lib/python3.14/site-packages/invenio_curations/services/service.py", line 245, in get_publishing_data
    "is_admin": is_identity_privileged(self.privileged_roles, identity),
                ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/instance/.venv/lib/python3.14/site-packages/invenio_curations/services/utils.py", line 36, in is_identity_privileged
    return any(role in privileged_roles for role in user.roles)
                                                    ^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'roles'
```