### PR TITLE
fix(ui): show all curation status states in despot form

### DIFF
--- a/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/CustomDepositStatusBox.js
+++ b/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/CustomDepositStatusBox.js
@@ -12,12 +12,8 @@ import { withCurationStatus } from "./withCurationStatus";
 const EnhancedStatusDisplay = withCurationStatus(StatusDisplay);
 
 // create the connected component that gets record state
-const mapStateToProps = (state) => {
-  const record = state.deposit.record;
-  return {
-    record: state.deposit.record,
-    request: record?.parent?.review || null,
-  };
-};
+const mapStateToProps = (state) => ({
+  record: state.deposit.record,
+});
 
 export const CustomDepositStatusBox = connect(mapStateToProps)(EnhancedStatusDisplay);

--- a/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/withCurationStatus.js
+++ b/invenio_curations/assets/semantic-ui/js/invenio_curations/deposit/withCurationStatus.js
@@ -15,8 +15,8 @@ import { i18next } from "@translations/invenio_curations/i18next";
 export const withCurationStatus = (WrappedComponent) => {
   const WithCurationStatus = ({ record, request, ...props }) => {
     const getStatusInfo = () => {
-      const isDraft = record?.status === 'draft_with_review';
       const isPublished = record?.is_published;
+      const isDraft = !isPublished;
 
       const hasValidationErrors = record?.ui?.validationErrors ||
         record?.errors?.length > 0 ||


### PR DESCRIPTION
 ### What does this PR do?                                                                  
                                                                                         
  Fixes the curation status display in the deposit form sidebar. Previously only "Draft" and "Ready for Review" were shown. The other states like "Under Review", "Declined",   "Needs revision", and "Ready to Publish" were never displayed.

 ### Problem:

  - with curation status checked record.status === 'draft_with_review' to decide if the record is a draft where this only matches when the curation request is in created state so after submission the record status changes to in_review, declined, or other state mapped byDraftStatus in invenio-rdm-records so the status switch block was always skipped.
  - in the deposit custom status was overwriting the curation request prop with record.parent.review from Redux, which is used for community reviews and was always null in the curation context.

 ### Changes:

  - changed draft check to !isPublished so all unpublished states are handled
  -  removed the request override from Redux mapping so the actual curation request passes through from DepositBox


<img width="408" height="265" alt="Screenshot 2026-03-05 at 14 34 19" src="https://github.com/user-attachments/assets/168f17f7-db6e-4ee0-9fe5-21013ce94251" />
<img width="413" height="290" alt="Screenshot 2026-03-05 at 14 31 54" src="https://github.com/user-attachments/assets/d525d3d4-bdd6-410f-b75d-84fff33c2632" />
<img width="429" height="206" alt="Screenshot 2026-03-05 at 14 31 14" src="https://github.com/user-attachments/assets/e04b628f-148f-4acc-8e83-3a11f09c4c8d" />
