### PR TITLE
view: curator overview improvements

### DIFF
--- a/invenio_curations/assets/semantic-ui/js/invenio_curations/requests/RequestMetadataLayout.js
+++ b/invenio_curations/assets/semantic-ui/js/invenio_curations/requests/RequestMetadataLayout.js
@@ -9,15 +9,103 @@
 import { i18next } from "@translations/invenio_requests/i18next";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
-import { Divider, Header } from "semantic-ui-react";
+import { Image } from "react-invenio-forms";
+import { Divider, Header, Icon, Message } from "semantic-ui-react";
 import { toRelativeTime } from "react-invenio-forms";
 import RequestStatus from "@js/invenio_requests/request/RequestStatus";
 import RequestTypeLabel from "@js/invenio_requests/request/RequestTypeLabel";
-import { RequestReviewers } from "@js/invenio_requests/request/reviewers/RequestReviewers";
-import {
-  EntityDetails,
-  DeletedResource,
-} from "@js/invenio_requests/request/RequestMetadata";
+
+// Sub-components for entity display (inlined for v13 compatibility — not exported by invenio-requests v13)
+const User = ({ user }) => (
+  <div className="flex">
+    <Image
+      src={user.links.avatar}
+      avatar
+      size="tiny"
+      className="mr-5"
+      ui={false}
+      rounded
+    />
+    <span>
+      {user.profile?.full_name ||
+        user?.username ||
+        user?.email ||
+        i18next.t("Anonymous user")}
+    </span>
+  </div>
+);
+
+User.propTypes = {
+  user: PropTypes.object.isRequired,
+};
+
+const Community = ({ community }) => (
+  <div className="flex">
+    <Image src={community.links.logo} avatar size="tiny" className="mr-5" ui={false} />
+    <a href={`/communities/${community.slug}`}>{community.metadata.title}</a>
+  </div>
+);
+
+Community.propTypes = {
+  community: PropTypes.object.isRequired,
+};
+
+const ExternalEmail = ({ email }) => (
+  <div className="flex">
+    <Icon name="mail" className="mr-5" />
+    <span>
+      {i18next.t("Email")}: {email.id}
+    </span>
+  </div>
+);
+
+ExternalEmail.propTypes = {
+  email: PropTypes.object.isRequired,
+};
+
+const Group = ({ group }) => (
+  <div className="flex">
+    <Icon name="group" className="mr-5" />
+    <span>
+      {i18next.t("Group")}: {group?.name}
+    </span>
+  </div>
+);
+
+Group.propTypes = {
+  group: PropTypes.object.isRequired,
+};
+
+const EntityDetails = ({ userData, details }) => {
+  const isUser = "user" in userData;
+  const isCommunity = "community" in userData;
+  const isExternalEmail = "email" in userData;
+  const isGroup = "group" in userData;
+
+  if (isUser) {
+    return <User user={details} />;
+  } else if (isCommunity) {
+    return <Community community={details} />;
+  } else if (isExternalEmail) {
+    return <ExternalEmail email={details} />;
+  } else if (isGroup) {
+    return <Group group={details} />;
+  }
+  return null;
+};
+
+EntityDetails.propTypes = {
+  userData: PropTypes.object.isRequired,
+  details: PropTypes.object.isRequired,
+};
+
+const DeletedResource = ({ details }) => (
+  <Message negative>{details.metadata.title}</Message>
+);
+
+DeletedResource.propTypes = {
+  details: PropTypes.object.isRequired,
+};
 
 // This component overrides the request metadata layout from InvenioApp RDM v13
 // Because the "original" request workflow from community-submission has the final
@@ -29,22 +117,15 @@ import {
 // to an error.
 // This override checks whether the link to the published record returns a positive status
 // and sets the state accordingly to be used in the rendering of the respective section.
-//
-// Apart from ATTENTION BLOCKs, the rest of the component is copy-pasted.
-// https://github.com/inveniosoftware/invenio-requests/blob/3596f4c2acd22c439a030fb9bab8d87e98c12a2e/invenio_requests/assets/semantic-ui/js/invenio_requests/request/RequestMetadata.js#L162C24-L162C61
-// it has been updated to include the RequestReviewers feature
 export class RequestMetadataComponent extends Component {
   constructor(props) {
     super(props);
 
-    // ATTENTION BLOCK state added for overridden component START
     this.state = {
       linkIsValid: false,
     };
-    // BLOCK END
   }
 
-  // ATTENTION BLOCK method was added to the component START
   componentDidMount() {
     const { request } = this.props;
 
@@ -64,34 +145,17 @@ export class RequestMetadataComponent extends Component {
         });
     }
   }
-  // BLOCK END
 
   isResourceDeleted = (details) => details.is_ghost === true;
 
   render() {
-    const { request, config, permissions } = this.props;
-    const { enableReviewers, allowGroupReviewers, maxReviewers } = config;
-
-    // ATTENTION BLOCK state: extra for overridden component START
+    const { request } = this.props;
     const { linkIsValid } = this.state;
-    // BLOCK END
 
     const expandedCreatedBy = request.expanded?.created_by;
     const expandedReceiver = request.expanded?.receiver;
     return (
       <>
-        {enableReviewers && (
-          <>
-            <RequestReviewers
-              request={request}
-              permissions={permissions}
-              allowGroupReviewers={allowGroupReviewers}
-              maxReviewers={maxReviewers}
-            />
-            <Divider />
-          </>
-        )}
-
         {expandedCreatedBy !== undefined && (
           <>
             <Header as="h3" size="tiny">
@@ -109,18 +173,22 @@ export class RequestMetadataComponent extends Component {
           </>
         )}
 
-        <Header as="h3" size="tiny">
-          {i18next.t("Receiver")}
-        </Header>
-        {this.isResourceDeleted(expandedReceiver) ? (
-          <DeletedResource details={expandedReceiver} />
-        ) : (
-          <EntityDetails
-            userData={request.receiver}
-            details={request.expanded?.receiver}
-          />
+        {expandedReceiver !== undefined && (
+          <>
+            <Header as="h3" size="tiny">
+              {i18next.t("Receiver")}
+            </Header>
+            {this.isResourceDeleted(expandedReceiver) ? (
+              <DeletedResource details={expandedReceiver} />
+            ) : (
+              <EntityDetails
+                userData={request.receiver}
+                details={request.expanded?.receiver}
+              />
+            )}
+            <Divider />
+          </>
         )}
-        <Divider />
 
         <Header as="h3" size="tiny">
           {i18next.t("Request type")}
@@ -149,7 +217,6 @@ export class RequestMetadataComponent extends Component {
           </>
         )}
 
-        {/* ATTENTION BLOCK state check: extra for overridden component START*/}
         {linkIsValid && (
           <>
             <Divider />
@@ -159,7 +226,6 @@ export class RequestMetadataComponent extends Component {
             <a href={`/records/${request.topic.record}`}>{request.title}</a>
           </>
         )}
-        {/* BLOCK END */}
       </>
     );
   }
@@ -167,10 +233,13 @@ export class RequestMetadataComponent extends Component {
 
 RequestMetadataComponent.propTypes = {
   request: PropTypes.object.isRequired,
-  config: PropTypes.object.isRequired,
-  permissions: PropTypes.object.isRequired,
+  config: PropTypes.object,
+  permissions: PropTypes.object,
 };
 
-RequestMetadataComponent.defaultProps = {};
+RequestMetadataComponent.defaultProps = {
+  config: {},
+  permissions: {},
+};
 
 export const RequestMetadata = RequestMetadataComponent;

--- a/invenio_curations/assets/semantic-ui/js/invenio_curations/requests/StatusLabel.js
+++ b/invenio_curations/assets/semantic-ui/js/invenio_curations/requests/StatusLabel.js
@@ -44,3 +44,11 @@ export const LabelStatusPendingResubmission = () => {
     </Label>
   );
 };
+
+export const LabelCommunityReviewOnHold = () => {
+  return (
+    <Label horizontal color="orange" size="tiny" basic>
+      {i18next.t("Community review on hold")}
+    </Label>
+  );
+};

--- a/invenio_curations/assets/semantic-ui/js/invenio_curations/search/CurationRequestItem.js
+++ b/invenio_curations/assets/semantic-ui/js/invenio_curations/search/CurationRequestItem.js
@@ -1,0 +1,171 @@
+// This file is part of InvenioRDM
+// Copyright (C) 2026 Graz University of Technology.
+//
+// Invenio-Curations is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { Icon, Item, Label } from "semantic-ui-react";
+
+import { DateTime } from "luxon";
+import PropTypes from "prop-types";
+import React from "react";
+import { RequestActionController } from "@js/invenio_requests/request/actions/RequestActionController";
+import RequestStatusLabel from "@js/invenio_requests/request/RequestStatusLabel";
+import { default as RequestTypeIcon } from "@js/invenio_requests/components/RequestTypeIcon";
+import RequestTypeLabel from "@js/invenio_requests/request/RequestTypeLabel";
+import { Trans } from "react-i18next";
+import { i18next } from "@translations/invenio_curations/i18next";
+import { toRelativeTime } from "react-invenio-forms";
+import { LabelCommunityReviewOnHold } from "../requests/StatusLabel";
+
+const getCreatorName = (result) => {
+  const isCreatorUser = "user" in result.created_by;
+  const isCreatorCommunity = "community" in result.created_by;
+  const isCreatorGuest = "email" in result.created_by;
+
+  if (isCreatorUser) {
+    return (
+      result.expanded?.created_by.profile?.full_name ||
+      result.expanded?.created_by.username ||
+      result.created_by.user
+    );
+  } else if (isCreatorCommunity) {
+    return (
+      result.expanded?.created_by.metadata?.title || result.created_by.community
+    );
+  } else if (isCreatorGuest) {
+    return result.created_by.email;
+  }
+  return "";
+};
+
+const statusLabels = {
+  submitted: i18next.t("Submitted"),
+  resubmitted: i18next.t("Resubmitted"),
+  review: i18next.t("Under review"),
+  critiqued: i18next.t("Changes requested"),
+  accepted: i18next.t("Accepted"),
+  declined: i18next.t("Declined"),
+  cancelled: i18next.t("Cancelled"),
+  pending_resubmission: i18next.t("Pending resubmission"),
+  created: i18next.t("Created"),
+};
+
+const LastStatusChange = ({ result }) => {
+  // Use updated timestamp as the last status change time
+  const status = result.status;
+  const updatedDate = result.updated;
+  const creatorName = getCreatorName(result);
+
+  if (!updatedDate || !status || status === "created") return null;
+
+  const label = statusLabels[status] || status;
+
+  return (
+    <small className="mt-5" style={{ display: "block" }}>
+      <Label size="tiny" color="yellow">
+        {label} {toRelativeTime(updatedDate, i18next.language)}
+        {creatorName && ` ${i18next.t("by")} ${creatorName}`}
+      </Label>
+    </small>
+  );
+};
+
+LastStatusChange.propTypes = {
+  result: PropTypes.object.isRequired,
+};
+
+export const CurationRequestItem = ({
+  result,
+  updateQueryState,
+  currentQueryState,
+  detailsURL,
+}) => {
+  const createdDate = new Date(result.created);
+  const creatorName = getCreatorName(result);
+  const hasCommunityReview = result.expanded?.topic?.parent?.review != null;
+
+  const getUserIcon = (receiver) => {
+    return receiver?.is_ghost ? "user secret" : "users";
+  };
+
+  return (
+    <Item key={result.id} className="computer tablet only flex">
+      <div className="status-icon mr-10">
+        <Item.Content verticalAlign="top">
+          <Item.Extra>
+            <RequestTypeIcon type={result.type} />
+          </Item.Extra>
+        </Item.Content>
+      </div>
+      <Item.Content>
+        <Item.Extra>
+          {result.type && <RequestTypeLabel type={result.type} />}
+          <RequestStatusLabel status={result.status} />
+          {hasCommunityReview && <LabelCommunityReviewOnHold />}
+          <div className="right floated">
+            <RequestActionController
+              request={result}
+              actionSuccessCallback={() => updateQueryState(currentQueryState)}
+            />
+          </div>
+        </Item.Extra>
+        <Item.Header
+          className={`truncate-lines-2 theme-primary-text ${
+            result.is_closed && "mt-5"
+          }`}
+        >
+          <a className="header-link" href={detailsURL}>
+            {result.title}
+          </a>
+        </Item.Header>
+        <Item.Meta>
+          <small>
+            <Trans
+              defaults="Opened {{relativeTime}} by"
+              values={{
+                relativeTime: toRelativeTime(
+                  createdDate.toISOString(),
+                  i18next.language
+                ),
+              }}
+            />{" "}
+            {creatorName}
+          </small>
+          <LastStatusChange result={result} />
+          <small className="right floated">
+            {result.receiver.community &&
+              result.expanded?.receiver.metadata.title && (
+                <>
+                  <Icon
+                    className="default-margin"
+                    name={getUserIcon(result.expanded?.receiver)}
+                  />
+                  <span className="ml-5">
+                    {result.expanded?.receiver.metadata.title}
+                  </span>
+                  {result.expires_at && " - "}
+                </>
+              )}
+            {result.expires_at && (
+              <span>
+                {i18next.t("Expires at: {{- expiringDate}}", {
+                  expiringDate: DateTime.fromISO(result.expires_at).toLocaleString(
+                    i18next.language
+                  ),
+                })}
+              </span>
+            )}
+          </small>
+        </Item.Meta>
+      </Item.Content>
+    </Item>
+  );
+};
+
+CurationRequestItem.propTypes = {
+  result: PropTypes.object.isRequired,
+  updateQueryState: PropTypes.func.isRequired,
+  currentQueryState: PropTypes.object.isRequired,
+  detailsURL: PropTypes.string.isRequired,
+};

--- a/invenio_curations/assets/semantic-ui/js/invenio_curations/search/index.js
+++ b/invenio_curations/assets/semantic-ui/js/invenio_curations/search/index.js
@@ -1,0 +1,79 @@
+// This file is part of InvenioRDM
+// Copyright (C) 2025 Graz University of Technology.
+//
+// Invenio-Curations is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+// NOTE: This entry point replaces invenio-app-rdm-user-requests.js for the
+// curation overview page. It mirrors the default search app setup from
+// invenio-app-rdm/user_dashboard/requests.js but uses a custom ResultsList.item.
+// When upgrading invenio-app-rdm or invenio-requests, check if the original
+// requests.js has added new default components or changed its setup.
+// See: invenio_app_rdm/theme/assets/semantic-ui/js/invenio_app_rdm/user_dashboard/requests.js
+
+import { createSearchAppInit } from "@js/invenio_search_ui";
+import {
+  ContribBucketAggregationElement,
+  ContribBucketAggregationValuesElement,
+  ContribSearchAppFacets,
+} from "@js/invenio_search_ui/components";
+import React from "react";
+import { overrideStore, parametrize } from "react-overridable";
+import { withState } from "react-searchkit";
+import { defaultContribComponents } from "@js/invenio_requests/contrib";
+import { RDMRecordSearchBarElement } from "@js/invenio_app_rdm/search/components";
+import {
+  MobileRequestItem,
+  RequestsSearchLayout,
+  RequestsEmptyResultsWithState,
+  RequestsResults,
+} from "@js/invenio_requests/search";
+import { CurationRequestItem } from "./CurationRequestItem";
+import { curationComponentOverrides } from "../requests";
+import PropTypes from "prop-types";
+
+const appName = "InvenioAppRdm.DashboardRequests";
+
+function CurationRequestsItemTemplate({ result }) {
+  const CurationRequestItemWithState = withState(CurationRequestItem);
+  const MobileRequestsItemWithState = withState(MobileRequestItem);
+  const detailsURL = `/me/requests/${result.id}`;
+  return (
+    <>
+      <CurationRequestItemWithState result={result} detailsURL={detailsURL} />
+      <MobileRequestsItemWithState result={result} detailsURL={detailsURL} />
+    </>
+  );
+}
+
+CurationRequestsItemTemplate.propTypes = {
+  result: PropTypes.object.isRequired,
+};
+
+const RequestsSearchLayoutWithApp = parametrize(RequestsSearchLayout, {
+  appName: appName,
+  showSharedFilters: true,
+});
+
+const defaultComponents = {
+  [`${appName}.BucketAggregation.element`]: ContribBucketAggregationElement,
+  [`${appName}.BucketAggregationValues.element`]: ContribBucketAggregationValuesElement,
+  [`${appName}.SearchApp.facets`]: ContribSearchAppFacets,
+  [`${appName}.ResultsList.item`]: CurationRequestsItemTemplate,
+  [`${appName}.ResultsGrid.item`]: () => null,
+  [`${appName}.SearchApp.layout`]: RequestsSearchLayoutWithApp,
+  [`${appName}.SearchApp.results`]: RequestsResults,
+  [`${appName}.SearchBar.element`]: RDMRecordSearchBarElement,
+  [`${appName}.EmptyResults.element`]: RequestsEmptyResultsWithState,
+  ...defaultContribComponents,
+  ...curationComponentOverrides,
+};
+
+const overriddenComponents = overrideStore.getAll();
+
+createSearchAppInit(
+  { ...defaultComponents, ...overriddenComponents },
+  true,
+  "invenio-search-config",
+  true
+);

--- a/invenio_curations/assets/semantic-ui/translations/invenio_curations/package-lock.json
+++ b/invenio_curations/assets/semantic-ui/translations/invenio_curations/package-lock.json
@@ -25,19 +25,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/acorn": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/acorn-class-fields": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.7.tgz",
@@ -2001,13 +1988,6 @@
         "regenerator-runtime": "^0.14.0"
       }
     },
-    "acorn": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
-      "dev": true,
-      "peer": true
-    },
     "acorn-class-fields": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.7.tgz",
@@ -2021,22 +2001,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
       "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-private-class-elements": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.7.tgz",
       "integrity": "sha512-+GZH2wOKNZOBI4OOPmzpo4cs6mW297sn6fgIk1dUI08jGjhAaEwvC39mN2gJAg2lmAQJ1rBkFqKWonL3Zz6PVA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-private-methods": {
       "version": "0.3.3",

--- a/invenio_curations/templates/semantic-ui/invenio_curations/overview.html
+++ b/invenio_curations/templates/semantic-ui/invenio_curations/overview.html
@@ -13,7 +13,7 @@ under the terms of the MIT License; see LICENSE file for more details.
 
 {%- block javascript %}
 {{ super() }}
-{{ webpack['invenio-app-rdm-user-requests.js'] }}
+{{ webpack['invenio-curations-search.js'] }}
 {%- endblock javascript %}
 
 {%- block user_dashboard_body %}

--- a/invenio_curations/webpack.py
+++ b/invenio_curations/webpack.py
@@ -29,6 +29,7 @@ curations = WebpackThemeBundle(
         "semantic-ui": dict(
             entry={
                 "invenio-curations-deposit": "./js/invenio_curations/deposit/index.js",
+                "invenio-curations-search": "./js/invenio_curations/search/index.js",
             },
             dependencies={},
             aliases={

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,9 @@ packages = find:
 python_requires = >=3.12
 zip_safe = False
 install_requires =
-    invenio-drafts-resources>=8.0.0
-    invenio-rdm-records>=24.0.0
-    invenio-requests>=12.0.0
+    invenio-drafts-resources>=3.0.0
+    invenio-rdm-records>=19.0.0
+    invenio-requests>=4.1.0
     nh3>=0.2.0
 
 [options.extras_require]


### PR DESCRIPTION
adds a custom search result item for the curation requests overview page. Each request now shows:                                                                                         
                                                                                                                                                                                            
  - Request status label — always visible, not just when the request is closed                                                                                                              
  - Last status change — shows when and by whom the last status change happened example: "Submitted 5 minutes ago by Admin User"
  
  _note: please ignore the styling (locally i have another setup):_
  
<img width="1079" height="215" alt="Screenshot 2026-03-06 at 12 44 13" src="https://github.com/user-attachments/assets/ae226153-3044-4f5e-bd86-6e5ff84b64bb" />
<img width="1064" height="198" alt="Screenshot 2026-03-06 at 12 44 04" src="https://github.com/user-attachments/assets/9ff60172-1c32-4c49-a654-c583cda6d7f9" />
