### PR TITLE
fix(service): do not cancel requests when discarding metadata edits

### DIFF
--- a/invenio_curations/services/components.py
+++ b/invenio_curations/services/components.py
@@ -113,15 +113,6 @@ class CurationComponent(ServiceComponent, ABC):
             _get_requests_service().delete(system_identity, request["id"], uow=self.uow)
             return
 
-        # Delete draft for a published record.
-        # Since only one request per record should exist, it is not deleted. Instead, put it back to accepted.
-        _get_requests_service().execute_action(
-            system_identity,
-            request["id"],
-            "cancel",
-            uow=self.uow,
-        )
-
     def _check_update_request(
         self,
         identity: Identity,  # noqa: ARG002


### PR DESCRIPTION
Previously, discarding drafts (i.e. metadata edits) for already published records would cause the system to cancel the curation request.
I.e. clicking "edit" for a published record, and then "discard changes" would cancel the (previously accepted) curation request.

This confused both users and reviewers alike in our system.