### PR TITLE
feat: support for invenio-checks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -441,3 +441,8 @@ The name of this role can be specified via a configuration variable ``CURATIONS_
 The following ``invenio roles`` command can be used to create the role if it doesn't exist yet: ``invenio roles create <name-of-curation-role>``.
 
 After the role has been created, it can be assigned to users via: ``invenio roles add <user-email-address> <name-of-curation-role>``.
+
+Checks
+~~~~~~
+
+This package supports ``invenio-checks`` validations. Submitting a curation request can trigger globally configured checks. For more information about how to configure checks, `check` `here <https://inveniordm.docs.cern.ch/operate/customize/curation-checks/#configuring-checks>`_.

--- a/invenio_curations/templates/semantic-ui/invenio_requests/rdm-curation/index.html
+++ b/invenio_curations/templates/semantic-ui/invenio_requests/rdm-curation/index.html
@@ -1,7 +1,7 @@
 {# -*- coding: utf-8 -*-
 
   Copyright (C) 2016-2023 CERN.
-  Copyright (C) 2024 Graz University of Technology.
+  Copyright (C) 2024-2026 Graz University of Technology.
 
   Invenio-Curations is free software; you can redistribute it and/or modify it
   under the terms of the MIT License; see LICENSE file for more details.
@@ -22,7 +22,7 @@
   {{ inclusion_request_header(
       request=invenio_request,
       record=record,
-      accepted=False, 
+      accepted=False,
       back_button_url=back_button_url,
       back_button_text=_("Back to requests")
     ) }}
@@ -60,6 +60,19 @@
         >
           {{ _("Record") }}
         </a>
+
+        {% if checks %}
+        <a
+          role="tab"
+          class="item"
+          data-tab="checks"
+          aria-selected="false"
+          aria-controls="checks-tab-panel"
+          id="checks-tab"
+        >
+          <i class="{% include 'invenio_checks/requests/overall_severity_level.html' %}"></i> {{ _("Checks") }}
+        </a>
+        {% endif %}
       </div>
     {% endif %}
 
@@ -74,7 +87,21 @@
       {{ super() }}
     </div>
 
-    {% if record %}
+    {% if checks %}
+      <div
+        class="ui bottom attached tab segment borderless"
+        data-tab="checks"
+        role="tabpanel"
+        aria-labelledby="checks-tab"
+        id="checks-tab-panel"
+        hidden="hidden"
+      >
+        {% include "invenio_checks/requests/details.html" %}
+      </div>
+    {% endif %}
+
+    {# The record tab content needs to be last since the HTML structure is complex and breaks following tab contents #}
+    {% if record_ui %}
       <div
         class="ui bottom attached tab segment borderless"
         data-tab="record"
@@ -85,7 +112,7 @@
       >
         {% set use_theme_basic_template = false %}
         {% set preview_submission_request = true %}
-        {% include "invenio_app_rdm/records/detail.html" %}
+        {% include config.APP_RDM_RECORD_LANDING_PAGE_TEMPLATE %}
       </div>
     {% endif %}
   </div>

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     invenio-drafts-resources>=8.0.0
     invenio-rdm-records>=24.0.0
     invenio-requests>=12.0.0
+    invenio-checks>=10.0.0
     nh3>=0.2.0
 
 [options.extras_require]


### PR DESCRIPTION
  * now that invenio-checks works without a hard-dependency on a community-id, invenio-curations can be safely a source for triggering global checks alongside community ones.
  * only changes necessary: update the request details template and add invenio-checks as dependency

Example:

<img width="2290" height="994" alt="image" src="https://github.com/user-attachments/assets/c4321bd4-6043-4ea2-89df-c2538926977e" />
<img width="2290" height="994" alt="image" src="https://github.com/user-attachments/assets/d2b079e0-2546-43a3-9a3c-9801fcf26c46" />
